### PR TITLE
Use poetry in tests of github workflow

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -41,6 +41,7 @@ jobs:
           source hisel-env/bin/activate
           python3 -m pip install --upgrade pip wheel setuptools
           python3 -m pip install poetry
+          python3 -m pip install pytest
           poetry lock
           poetry install --with test
 


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->
the script `run_tests.yaml` installs the dependencies required by `hisel` using `pip` and the requirement file `requirements-test.txt`. This is not aligned to the intended management of the dependencies, which is via `poetry`. This PR proposes to unify these two approaches to dependence management, and it replaces the usage of `pip` and requirement files in the github tests with poetry commands.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
