### PR TITLE
Github actions - Set the flag QUICK_TEST to False

### DIFF
--- a/tests/kernel_test.py
+++ b/tests/kernel_test.py
@@ -7,7 +7,7 @@ import datetime
 
 pyhsiclasso_recon = True
 
-QUICK_TEST = True
+QUICK_TEST = False
 
 
 class KernelTest(unittest.TestCase):

--- a/tests/select_test.py
+++ b/tests/select_test.py
@@ -17,7 +17,7 @@ try:
 except (ModuleNotFoundError, ImportError):
     SKIP_CUDA = True
 
-QUICK_TEST = True
+QUICK_TEST = False
 SKIP_CUDA = True if QUICK_TEST else SKIP_CUDA
 use_pyhsiclasso = False if QUICK_TEST else use_pyhsiclasso
 


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->
This PR exposes the issue with running the entire set of tests in the github workflow. 
By setting `QUICK_TEST` to `False` in `kernel_test.py` and `select_test.py`, no tests that can be executed with numpy only are skipped. As a result, Error 137 is raised.  

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
