### PR TITLE
Nonlinear transformation example - Effectiveness of HSICSelector

### DIFF
--- a/notebooks/nonlinear-transform.ipynb
+++ b/notebooks/nonlinear-transform.ipynb
@@ -20,7 +20,7 @@
    "id": "c2559eae",
    "metadata": {},
    "source": [
-    "### Sin transform "
+    "# Sin transform "
    ]
   },
   {
@@ -134,18 +134,8 @@
     "    batch_size=batch_size,\n",
     "    minibatch_size=minibatch_size,\n",
     "    number_of_epochs=number_of_epochs\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "994a64fc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "paths = projector.lasso_path()\n",
-    "paths"
+    ")\n",
+    "paths = projector.lasso_path()"
    ]
   },
   {
@@ -190,10 +180,54 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a8bf88af",
+   "metadata": {},
+   "source": [
+    "## Comparison with sklearn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "332ba768",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.feature_selection import f_regression, mutual_info_regression"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0b76ba28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fstats, _ = f_regression(x_samples, np.linalg.norm(y_samples, axis=1))\n",
+    "fstats /= np.max(fstats)\n",
+    "f_selection = np.argmax(fstats)\n",
+    "print(f'f_selection: {f_selection}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ceec08f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mi = mutual_info_regression(x_samples, np.linalg.norm(y_samples, axis=1))\n",
+    "mi /= np.max(mi)\n",
+    "mi_selection = np.argmax(mi)\n",
+    "print(f'mi_selection: {mi_selection}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "7771b83e",
    "metadata": {},
    "source": [
-    "### Linear and non-linear  transformation in high dimension"
+    "# Linear and non-linear  transformation in high dimension"
    ]
   },
   {
@@ -327,8 +361,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "paths = projector.lasso_path()\n",
-    "paths"
+    "paths = projector.lasso_path()"
    ]
   },
   {
@@ -369,6 +402,51 @@
     "selected_features = np.argsort(paths.iloc[-1, :])[::-1][:dim_z]\n",
     "print(f'Expected features: {sorted(list(expected_features))}')\n",
     "print(f'Selected features: {sorted(list(selected_features))}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87b7675f",
+   "metadata": {},
+   "source": [
+    "## Comparison with sklearn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30f6f83b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.feature_selection import f_regression, mutual_info_regression"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24df734c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fstats, _ = f_regression(x_samples, np.linalg.norm(y_samples, axis=1))\n",
+    "fstats /= np.max(fstats)\n",
+    "f_selection = np.argsort(fstats)[::-1][:dim_z]\n",
+    "print(f'f_selection: {sorted(f_selection)}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d84477ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mi = mutual_info_regression(x_samples, np.linalg.norm(y_samples, axis=1))\n",
+    "mi /= np.max(mi)\n",
+    "mi_selection = np.argsort(mi)[::-1][:dim_z]\n",
+    "print(f'mutual information: {mi[mi_selection]}')\n",
+    "print(f'mi_selection: {sorted(mi_selection)}')"
    ]
   },
   {


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->
The Hilbert-Schmidt Independence Criterion is capable of detecting non-linear dependence between random variables.
As a result, `hisel` is effective in selecting features when the dependence with the target is non-linear. 
We demonstrate this in a notebook. This PR contains that notebook. 

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
