### PR TITLE
Bump pyproject.toml to version 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hisel"
-version = "0.3.0"
+version = "0.2.1"
 description = ""
 authors = ["claudio <claudio.bellani@transferwise.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->
Release of v0.2.0 is problematic. The new version does not seem to be picked from `pyproject.toml`. So, I am trying to release v.0.2.1 after this PR gets merged

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
