### PR TITLE
Dependencies - downgrade pandas to >=1.5.3

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -266,4 +266,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "<3.12,>=3.8"
-content-hash = "5ead60028ddf61d40c27b39ddf77f8070261a9b8972e841cf729f51a877db9f1"
+content-hash = "c877d7dded830f323893792beb440c40504a20ca288ec5dbdd9089982b78cb76"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "<3.12,>=3.8"
 numpy = ">=1.23"
-pandas = ">=2.0"
+pandas = ">=1.5.3"
 scipy = ">=1.10"
 scikit-learn = ">=1.2.0"
 


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->
If you use pandas>=2.0 with CatBoost, you'll find that fitting a model would raise 
```
AttributeError: 'DataFrame' object has no attribute 'iteritems'
```

Therefore this PR relaxes the requirements on pandas and it downgrade it to 1.5.3. In this way, `hisel` and `Catboost` can run in the same environment. 


## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
