### PR TITLE
Remove Run trufflehog check from tw-rules

### DIFF
--- a/.github/tw-rules.yaml
+++ b/.github/tw-rules.yaml
@@ -12,9 +12,6 @@ actions:
           - name: hisel tests
             appId: github-actions
             type: tests
-          - name: Run trufflehog to catch credential leaks
-            appId: github-actions
-            type: tests
 
   repo-settings:
     deleteBranchOnMerge: true


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->
This PR changes the tw-rules.yml and it removes the check `Run trufflehog to catch credential leaks`. This is meant to resolve the impasse of #47 

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
